### PR TITLE
SAML-2 custom nameid formats

### DIFF
--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -14,11 +14,11 @@ component {
 		settings.saml2.attributes = {};
 		settings.saml2.attributes.retrievalHandler = "saml2.retrieveAttributes";
 		settings.saml2.attributes.supported = {
-			  id          = { friendlyName="UserID"                                                  , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" }
-			, email       = { friendlyName="Email"      , samlUrn="urn:oid:0.9.2342.19200300.100.1.3", samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" }
-			, displayName = { friendlyName="DisplayName", samlUrn="urn:oid:2.16.840.1.113730.3.1.241", samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" }
-			, firstName   = { friendlyName="FirstName"  , samlUrn="urn:oid:2.5.4.42"                 , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" }
-			, lastName    = { friendlyName="LastName"   , samlUrn="urn:oid:2.5.4.4"                  , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" }
+			  id          = { friendlyName="UserID"                                                  , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="persistent" }
+			, email       = { friendlyName="Email"      , samlUrn="urn:oid:0.9.2342.19200300.100.1.3", samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="email" }
+			, displayName = { friendlyName="DisplayName", samlUrn="urn:oid:2.16.840.1.113730.3.1.241", samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="unspecified" }
+			, firstName   = { friendlyName="FirstName"  , samlUrn="urn:oid:2.5.4.42"                 , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="unspecified" }
+			, lastName    = { friendlyName="LastName"   , samlUrn="urn:oid:2.5.4.4"                  , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="unspecified" }
 		};
 
 		settings.saml2.identityProviders = settings.saml2.identityProviders ?: {};
@@ -45,6 +45,7 @@ component {
 
 		settings.enum.samlSsoType = [ "sp", "idp" ];
 		settings.enum.samlIdpType = [ "admin", "web" ];
+		settings.enum.samlNameIdFormat = [ "auto", "persistent", "email", "unspecified", "transient", "none" ];
 
 		settings.multilingual.ignoredUrlPatterns = settings.multilingual.ignoredUrlPatterns ?: [];
 		settings.multilingual.ignoredUrlPatterns.append( "^/saml2/" );

--- a/forms/preside-objects/saml2_consumer/admin.add.xml
+++ b/forms/preside-objects/saml2_consumer/admin.add.xml
@@ -12,9 +12,9 @@
 	</tab>
 	<tab id="attributes">
 		<fieldset id="attributes" sortorder="20">
-			<field binding="saml2_consumer.id_attribute"              sortorder="10" control="samlAssertionAttributesPicker"/>
-			<field binding="saml2_consumer.id_attribute_is_transient" sortorder="20" />
-			<field binding="saml2_consumer.use_attributes"            sortorder="30" control="samlAssertionAttributesPicker" multiple="true" />
+			<field binding="saml2_consumer.id_attribute"        sortorder="10" control="samlAssertionAttributesPicker"/>
+			<field binding="saml2_consumer.id_attribute_format" sortorder="20" control="enumRadioList" />
+			<field binding="saml2_consumer.use_attributes"      sortorder="30" control="samlAssertionAttributesPicker" multiple="true" />
 		</fieldset>
 	</tab>
 	<tab id="editorial">

--- a/forms/preside-objects/saml2_consumer/admin.edit.xml
+++ b/forms/preside-objects/saml2_consumer/admin.edit.xml
@@ -12,9 +12,9 @@
 	</tab>
 	<tab id="attributes">
 		<fieldset id="attributes" sortorder="20">
-			<field binding="saml2_consumer.id_attribute"              sortorder="10" control="samlAssertionAttributesPicker"/>
-			<field binding="saml2_consumer.id_attribute_is_transient" sortorder="20" />
-			<field binding="saml2_consumer.use_attributes"            sortorder="30" control="samlAssertionAttributesPicker" multiple="true" />
+			<field binding="saml2_consumer.id_attribute"        sortorder="10" control="samlAssertionAttributesPicker"/>
+			<field binding="saml2_consumer.id_attribute_format" sortorder="20" control="enumRadioList" />
+			<field binding="saml2_consumer.use_attributes"      sortorder="30" control="samlAssertionAttributesPicker" multiple="true" />
 		</fieldset>
 	</tab>
 	<tab id="editorial">

--- a/handlers/Saml2.cfc
+++ b/handlers/Saml2.cfc
@@ -69,7 +69,7 @@ component {
 				  issuer          = issuer
 				, inResponseTo    = samlRequest.samlRequest.id
 				, recipientUrl    = redirectLocation
-				, nameIdFormat    = "urn:oasis:names:tc:SAML:2.0:nameid-format:#attributeConfig.idFormat#"
+				, nameIdFormat    = attributeConfig.idFormat
 				, nameIdValue     = attributeConfig.idValue
 				, audience        = samlRequest.issuerEntity.id
 				, sessionTimeout  = 40
@@ -264,8 +264,8 @@ component {
 
 	private struct function _getAttributeConfig( required struct consumerRecord ) {
 		var attributes = samlAttributesService.getAttributeValues();
+		var idFormat   = samlAttributesService.getNameIdFormat( consumerRecord = consumerRecord );
 		var idValue    = attributes[ consumerRecord.id_attribute ?: "" ] ?: getLoggedInUserId();
-		var idFormat   = IsTrue( consumerRecord.id_attribute_is_transient ?: "" ) ? "transient" : "persistent";
 		var restricted = ( consumerRecord.use_attributes ?: "" ).listToArray();
 
 		if ( restricted.len() ) {

--- a/handlers/admin/Saml2Admin.cfc
+++ b/handlers/admin/Saml2Admin.cfc
@@ -102,6 +102,14 @@ component extends="preside.system.base.AdminHandler" {
 
 		prc.consumer = QueryRowToStruct( prc.consumer );
 
+		if ( !Len( prc.consumer.id_attribute_format ?: "" ) ) {
+			if ( isTrue( prc.consumer.id_attribute_is_transient ?: "" ) ) {
+				prc.consumer.id_attribute_format = "transient";
+			} else {
+				prc.consumer.id_attribute_format = "auto";
+			}
+		}
+
 		prc.pageTitle    = translateResource( uri="saml2:provider.editConsumer.page.title", data=[ prc.consumer.name ] );
 		prc.pageSubTitle = translateResource( uri="saml2:provider.editConsumer.page.subtitle", data=[ prc.consumer.name ] );
 

--- a/i18n/enum/samlNameIdFormat.properties
+++ b/i18n/enum/samlNameIdFormat.properties
@@ -1,23 +1,23 @@
 auto.label=Automatic
 auto.description=(recommended) the system will pick the appropriate NameID format for you based on the choice of NameID field
-auto.full.format=
+auto.uri=
 
 persistent.label=Persistent
 persistent.description=Used for psuedo-random identifiers for a user that will not change - i.e. perfect for "user ID" or "contact ID"
-persistent.full.format=urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+persistent.uri=urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
 
 transient.label=Transient
 transient.description=Used for identifiers that should not be relied on to be constant (not recommended)
-transient.full.format=urn:oasis:names:tc:SAML:2.0:nameid-format:transient
+transient.uri=urn:oasis:names:tc:SAML:2.0:nameid-format:transient
 
 email.label=Email
 email.description=Used when the NameID field contains an email address
-email.full.format=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+email.uri=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
 
 unspecified.label=Unspecified
 unspecified.description=No specific information about the format of the NameID field is communicated. Required by some providers.
-unspecified.full.format=urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+unspecified.uri=urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 
 none.label=None
 none.description=Do not specify a NameID format at all. Service providers should interpret this as "Unspecified".
-none.full.format=
+none.uri=

--- a/i18n/enum/samlNameIdFormat.properties
+++ b/i18n/enum/samlNameIdFormat.properties
@@ -1,5 +1,5 @@
 auto.label=Automatic
-auto.description=(recommended) the system will pick the appropriate NameID format for you based on the choice of NameID field
+auto.description=(recommended) the system will pick the appropriate ID format for you based on the choice of ID attribute
 auto.uri=
 
 persistent.label=Persistent
@@ -11,13 +11,13 @@ transient.description=Used for identifiers that should not be relied on to be co
 transient.uri=urn:oasis:names:tc:SAML:2.0:nameid-format:transient
 
 email.label=Email
-email.description=Used when the NameID field contains an email address
+email.description=Used when the ID attribute contains an email address
 email.uri=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
 
 unspecified.label=Unspecified
-unspecified.description=No specific information about the format of the NameID field is communicated. Required by some providers.
+unspecified.description=No specific information about the format of the ID attribute is communicated. Required by some providers.
 unspecified.uri=urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
 
 none.label=None
-none.description=Do not specify a NameID format at all. Service providers should interpret this as "Unspecified".
+none.description=Do not specify an ID format at all. Service providers should interpret this as "Unspecified".
 none.uri=

--- a/i18n/enum/samlNameIdFormat.properties
+++ b/i18n/enum/samlNameIdFormat.properties
@@ -1,0 +1,23 @@
+auto.label=Automatic
+auto.description=(recommended) the system will pick the appropriate NameID format for you based on the choice of NameID field
+auto.full.format=
+
+persistent.label=Persistent
+persistent.description=Used for psuedo-random identifiers for a user that will not change - i.e. perfect for "user ID" or "contact ID"
+persistent.full.format=urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+
+transient.label=Transient
+transient.description=Used for identifiers that should not be relied on to be constant (not recommended)
+transient.full.format=urn:oasis:names:tc:SAML:2.0:nameid-format:transient
+
+email.label=Email
+email.description=Used when the NameID field contains an email address
+email.full.format=urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+
+unspecified.label=Unspecified
+unspecified.description=No specific information about the format of the NameID field is communicated. Required by some providers.
+unspecified.full.format=urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified
+
+none.label=None
+none.description=Do not specify a NameID format at all. Service providers should interpret this as "Unspecified".
+none.full.format=

--- a/i18n/preside-objects/saml2_consumer.properties
+++ b/i18n/preside-objects/saml2_consumer.properties
@@ -34,6 +34,10 @@ field.use_attributes.help=Select the user attributes that will be provided to th
 field.id_attribute.title=ID Attribute
 field.id_attribute.placeholder=Select an attribute or leave empty for default (recommended)
 field.id_attribute.help=Select the attribute that should be used as the user ID for the service provider.
+
+field.id_attribute_format.title=ID Attribute Format
+field.id_attribute_format.help=The ID Attribute format is used to tell Service Providers about the nature of the ID they are receiving. If in doubt, leave this as default (automatic).
+
 field.id_attribute_is_transient.title=ID is transient?
 field.id_attribute_is_transient.help=Whether or not the ID attribute is a transient value (i.e. subject to change). THIS SHOULD ALMOST CERTAINLY BE *NOT* TICKED.
 

--- a/preside-objects/saml2_consumer.cfc
+++ b/preside-objects/saml2_consumer.cfc
@@ -11,7 +11,9 @@ component  {
 	property name="sso_type"                  type="string"  dbtype="varchar" maxlength=3 enum="samlSsoType" renderer="samlSsoType";
 	property name="use_attributes"            type="string"  dbtype="text";
 	property name="id_attribute"              type="string"  dbtype="varchar" maxlength=200;
-	property name="id_attribute_is_transient" type="boolean" dbtype="boolean" default=false;
+	property name="id_attribute_format"       type="string"  dbtype="varchar" maxlength=15 enum="samlNameIdFormat";
+
+	property name="id_attribute_is_transient" type="boolean" dbtype="boolean" default=false; // field is deprecated, but here for backward compatibility
 
 	property name="access_condition" relationship="many-to-one" relatedto="rules_engine_condition";
 

--- a/services/SamlAttributesService.cfc
+++ b/services/SamlAttributesService.cfc
@@ -31,6 +31,29 @@ component {
 		);
 	}
 
+	public string function getNameIdFormat( required struct consumerRecord ) {
+		var explicitFormat = consumerRecord.id_attribute_format ?: "";
+
+		if ( !Len( explicitFormat ) ) {
+			if ( IsBoolean( consumerRecord.id_attribute_is_transient ?: "" ) && consumerRecord.id_attribute_is_transient ) {
+				explicitFormat = "transient";
+			} else {
+				explicitFormat = "auto";
+			}
+		}
+
+		if ( explicitFormat == "auto" ) {
+			var attribConfig = _getSupportedAttributes();
+			var idField = consumerRecord.id_attribute ?: "";
+			if ( !Len( idField ) ) {
+				idField = "id";
+			}
+			explicitFormat = attribConfig[ idField ].nameIdFormat ?: "unspecified";
+		}
+
+		return $translateResource( uri="enum.samlNameIdFormat:#explicitFormat#.uri", defaultValue="" );
+	}
+
 // PRIVATE HELPERS
 
 // GETTERS AND SETTERS

--- a/services/SamlResponseBuilder.cfc
+++ b/services/SamlResponseBuilder.cfc
@@ -144,7 +144,12 @@ component {
 
 	private string function _getSubject( required date instant, required string nameIdFormat, required string nameIdValue, required string inResponseTo, required string recipientUrl ) {
 		var xml  = '<saml:Subject>';
-		    xml &= '<saml:NameID Format="#arguments.nameIdFormat#">#nameIdValue#</saml:NameID>';
+
+		if ( Len( Trim( arguments.nameIdFormat ) ) ) {
+			xml &= '<saml:NameID Format="#arguments.nameIdFormat#">#nameIdValue#</saml:NameID>';
+		} else {
+			xml &= '<saml:NameID>#nameIdValue#</saml:NameID>';
+		}
 
 		if ( arguments.inResponseTo.len() ) {
 		    xml &= '<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">';

--- a/tests/unit/ResponseBuilderTest.cfc
+++ b/tests/unit/ResponseBuilderTest.cfc
@@ -2,7 +2,7 @@ component extends="testbox.system.BaseSpec" {
 
 	function run() {
 		describe( "buildAuthenticationAssertion()", function(){
-			xit( "should return minimal authentication assertion response XML with minimal args", function(){
+			it( "should return minimal authentication assertion response XML with minimal args", function(){
 				var builder  = _getBuilder();
 				var response = builder.buildAuthenticationAssertion(
 					  issuer              = "http://www.thewebsite.com/"
@@ -17,6 +17,33 @@ component extends="testbox.system.BaseSpec" {
 				);
 
 				expect( IsXml( response ) ).toBeTrue();
+				expect( response contains "<saml:NameID Format" ).toBeTrue();
+
+				var openSamlObjectRepresentingResponse = new samlIdProvider.OpenSamlUtils().xmlToOpenSamlObject( response );
+				try {
+					openSamlObjectRepresentingResponse.validate( true );
+				} catch ( any e ) {
+					fail( "SAML did not validate" );
+				}
+			} );
+
+			it( "should leave out format attribute of nameId when format is empty", function(){
+				var builder  = _getBuilder();
+				var response = builder.buildAuthenticationAssertion(
+					  issuer              = "http://www.thewebsite.com/"
+					, nameIdFormat        = ""
+					, nameIdValue         = "test@test.com"
+					, inResponseTo        = "aaf23196-1773-2113-474a-fe114412ab72"
+					, recipientUrl        = "https://sp.example.com/SAML2/SSO/POST"
+					, audience            = "https://sp.example.com/SAML2"
+					, sessionTimeout      = 30
+					, sessionIndex        = "C894146D-598F-4D9B-8733ACF80280C4B7"
+					, attributes          = { email = "test@test.com", displayName="Test user", firstName="Test", lastName="user" }
+				);
+
+				expect( IsXml( response ) ).toBeTrue();
+				expect( response contains "<saml:NameID>test@test.com</saml:NameID>" ).toBeTrue();
+				expect( response contains "<saml:NameID Format" ).toBeFalse();
 
 				var openSamlObjectRepresentingResponse = new samlIdProvider.OpenSamlUtils().xmlToOpenSamlObject( response );
 				try {

--- a/tests/unit/SamlAttributesServiceTest.cfc
+++ b/tests/unit/SamlAttributesServiceTest.cfc
@@ -1,0 +1,97 @@
+component extends="testbox.system.BaseSpec" {
+
+	function run() {
+		describe( "getNameIdFormat", function() {
+			it( "should return the full URI for the explicitly set format against a service provider", function(){
+				var svc                = _getService();
+				var fullUri            = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+				var stubConsumerRecord = {
+					  id_attribute_format       = "email"
+					, id_attribute_is_transient = 0
+				};
+
+				svc.$( "$translateResource" ).$args( uri="", defaultValue="enum.samlNameIdFormat:email.uri" ).$results( fullUri );
+				svc.$( "$translateResource", "notfound" );
+
+				expect( svc.getNameIdFormat( stubConsumerRecord ) ).toBe( fullUri );
+			} );
+
+			it( "should use email URI when the name id field is email and the saved format is 'auto'", function(){
+				var svc                = _getService();
+				var fullUri            = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
+				var stubConsumerRecord = {
+					  id_attribute_format       = "auto"
+					, id_attribute_is_transient = 0
+					, id_attribute              = "email"
+				};
+
+				svc.$( "$translateResource" ).$args( uri="", defaultValue="enum.samlNameIdFormat:email.uri" ).$results( fullUri );
+				svc.$( "$translateResource", "notfound" );
+
+				expect( svc.getNameIdFormat( stubConsumerRecord ) ).toBe( fullUri );
+			} );
+
+			it( "should use persistent URI when the name id field is id and the saved format is 'auto'", function(){
+				var svc                = _getService();
+				var fullUri            = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
+				var stubConsumerRecord = {
+					  id_attribute_format       = "auto"
+					, id_attribute_is_transient = 0
+					, id_attribute              = "id"
+				};
+
+				svc.$( "$translateResource" ).$args( uri="", defaultValue="enum.samlNameIdFormat:persistent.uri" ).$results( fullUri );
+				svc.$( "$translateResource", "notfound" );
+
+				expect( svc.getNameIdFormat( stubConsumerRecord ) ).toBe( fullUri );
+			} );
+
+			it( "should use unspecified URI when the name id field is not configured and the saved format is 'auto'", function(){
+				var svc                = _getService();
+				var fullUri            = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+				var stubConsumerRecord = {
+					  id_attribute_format = "auto"
+					, id_attribute        = "nonexistentidattrib"
+				};
+
+				svc.$( "$translateResource" ).$args( uri="", defaultValue="enum.samlNameIdFormat:unspecified.uri" ).$results( fullUri );
+				svc.$( "$translateResource", "notfound" );
+
+				expect( svc.getNameIdFormat( stubConsumerRecord ) ).toBe( fullUri );
+			} );
+
+			it( "should use transient URI when there is no saved format and when the legacy is_transient field is set to true", function(){
+				var svc                = _getService();
+				var fullUri            = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient";
+				var stubConsumerRecord = {
+					  id_attribute_format = ""
+					, id_attribute_is_transient = 1
+					, id_attribute = "id"
+				};
+
+				svc.$( "$translateResource" ).$args( uri="", defaultValue="enum.samlNameIdFormat:transient.uri" ).$results( fullUri );
+				svc.$( "$translateResource", "notfound" );
+
+				expect( svc.getNameIdFormat( stubConsumerRecord ) ).toBe( fullUri );
+			} );
+		} );
+	}
+
+	private any function _getService( struct supportedAttributes=_defaultSupportedAttibutes(), attributeRetrievalHandler="test.attrib.retrieval.handler" ) {
+		var svc = CreateObject( "app.extensions.preside-ext-saml2-sso.services.SamlAttributesService" ).init( argumentCollection=arguments );
+
+		svc = CreateMock( object=svc );
+
+		return svc;
+	}
+
+	private struct function _defaultSupportedAttibutes() {
+		return {
+			  id          = { friendlyName="UserID"                                                  , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="persistent" }
+			, email       = { friendlyName="Email"      , samlUrn="urn:oid:0.9.2342.19200300.100.1.3", samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="email" }
+			, displayName = { friendlyName="DisplayName", samlUrn="urn:oid:2.16.840.1.113730.3.1.241", samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="unspecified" }
+			, firstName   = { friendlyName="FirstName"  , samlUrn="urn:oid:2.5.4.42"                 , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="unspecified" }
+			, lastName    = { friendlyName="LastName"   , samlUrn="urn:oid:2.5.4.4"                  , samlNameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri", nameIdFormat="unspecified" }
+		};
+	}
+}


### PR DESCRIPTION
Adds user customisation of NameID format for created service providers in the system. To help workaround SPs that limit these formats for whatever reason.