### PR TITLE
SAMLcertificate 3072 bit

### DIFF
--- a/config/Config.cfc
+++ b/config/Config.cfc
@@ -4,6 +4,7 @@ component {
 		var settings = arguments.config.settings ?: {};
 
 		settings.saml2 = {};
+		settings.saml2.keySize = Val( settings.env.SAML2_KEY_SIZE ?: 2048 );
 
 		_configureExtensionSettings( settings );
 		_configureFeatures( settings );

--- a/services/saml/signing/SamlCertificateService.cfc
+++ b/services/saml/signing/SamlCertificateService.cfc
@@ -5,6 +5,7 @@
 component {
 
 	property name="samlProviderMetadataGenerator" inject="delayedInjector:samlProviderMetadataGenerator";
+	property name="configuredKeySize"             inject="coldbox:setting:saml2.keySize";
 
 // CONSTRUCTOR
 	public any function init() {
@@ -22,12 +23,12 @@ component {
 		};
 	}
 
-	public struct function generateKeyPair( expiryDays=7300, cn=_getCnForCertificates() ) {
+	public struct function generateKeyPair( expiryDays=7300, cn=_getCnForCertificates(), keySize=configuredKeySize ) {
 		var filePath     = ExpandPath( "/uploads/saml2/tmpkeystore#CreateUUId()#" );
 		var certAlias    = "generated";
 		var certPassword = CreateUUId();
 		var password     = CreateUUId();
-		var keyToolArgs  = '-genkeypair -validity #arguments.expiryDays# -alias #certAlias# -keyalg RSA -storetype JKS -keystore #filePath# -storepass #password# -keysize 3072 -keypass #certPassword# -dname CN=#arguments.cn#'.split( "\s+" );
+		var keyToolArgs  = '-genkeypair -validity #arguments.expiryDays# -alias #certAlias# -keyalg RSA -storetype JKS -keystore #filePath# -storepass #password# -keysize #arguments.keySize# -keypass #certPassword# -dname CN=#arguments.cn#'.split( "\s+" );
 
 		// TODO, replace this with a java lib for generating the keypair
 		// should keytool fail, it crashes the server :o

--- a/services/saml/signing/SamlCertificateService.cfc
+++ b/services/saml/signing/SamlCertificateService.cfc
@@ -27,7 +27,7 @@ component {
 		var certAlias    = "generated";
 		var certPassword = CreateUUId();
 		var password     = CreateUUId();
-		var keyToolArgs  = '-genkeypair -validity #arguments.expiryDays# -alias #certAlias# -keyalg RSA -storetype JKS -keystore #filePath# -storepass #password# -keysize 2048 -keypass #certPassword# -dname CN=#arguments.cn#'.split( "\s+" );
+		var keyToolArgs  = '-genkeypair -validity #arguments.expiryDays# -alias #certAlias# -keyalg RSA -storetype JKS -keystore #filePath# -storepass #password# -keysize 3072 -keypass #certPassword# -dname CN=#arguments.cn#'.split( "\s+" );
 
 		// TODO, replace this with a java lib for generating the keypair
 		// should keytool fail, it crashes the server :o


### PR DESCRIPTION
update SAML certificate from 2048 to 3072 bit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SAML signing key generation parameters, which can impact cryptographic compatibility and performance for IdP/SP integrations. Scope is small (single argument change) but affects security-sensitive certificate generation.
> 
> **Overview**
> Updates SAML certificate generation in `SamlCertificateService.generateKeyPair()` to create **3072-bit RSA** keys (from 2048-bit) when invoking Java `keytool`, strengthening generated signing credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9354c96b422f581db64e5533ec0dcec84c44f63a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->