### PR TITLE
Display certificate fingerprints

### DIFF
--- a/handlers/renderers/content/X509Summary.cfc
+++ b/handlers/renderers/content/X509Summary.cfc
@@ -15,8 +15,8 @@ component {
 					, selfIssued        = certObj.isSelfIssued( certObj )
 					, expires           = certObj.getNotAfter()
 					, valid             = true
-					, fingerprintSha256 = samlCertificateService.getCertificateFingerprint( cert, "SHA-256" )
-					, fingerprintSha1   = samlCertificateService.getCertificateFingerprint( cert, "SHA-1" )
+					, fingerprintSha256 = samlCertificateService.getCertificateFingerprint( certObj, "SHA-256" )
+					, fingerprintSha1   = samlCertificateService.getCertificateFingerprint( certObj, "SHA-1" )
 				};
 
 				try {

--- a/handlers/renderers/content/X509Summary.cfc
+++ b/handlers/renderers/content/X509Summary.cfc
@@ -1,6 +1,7 @@
 component {
 
-	property name="x509CertReader" inject="x509CertReader";
+	property name="x509CertReader"         inject="x509CertReader";
+	property name="samlCertificateService" inject="samlCertificateService";
 
 	public string function default( event, rc, prc, args={} ){
 		var cert = args.data ?: "";
@@ -10,10 +11,12 @@ component {
 				var certObj = x509CertReader.read( cert );
 
 				args.certInfo = {
-					  issuer     = certObj.getIssuerDN().toString()
-					, selfIssued = certObj.isSelfIssued( certObj )
-					, expires = certObj.getNotAfter()
-					, valid = true
+					  issuer            = certObj.getIssuerDN().toString()
+					, selfIssued        = certObj.isSelfIssued( certObj )
+					, expires           = certObj.getNotAfter()
+					, valid             = true
+					, fingerprintSha256 = samlCertificateService.getCertificateFingerprint( cert, "SHA-256" )
+					, fingerprintSha1   = samlCertificateService.getCertificateFingerprint( cert, "SHA-1" )
 				};
 
 				try {

--- a/i18n/saml2.properties
+++ b/i18n/saml2.properties
@@ -109,6 +109,8 @@ no.providers.message=There are no identity providers configured. Registering Ide
 x509.info.table.expires.th=Expires:
 x509.info.table.casigned.th=CA&nbsp;Signed?:
 x509.info.table.issuer.th=Issuer:
+x509.info.table.fingerprint.sha256.th=Fingerprint (SHA-256):
+x509.info.table.fingerprint.sha1.th=Fingerprint (SHA-1):
 x509.info.table.certificate.th=Certificate:
 
 error.no.meta.supplied=No metadata was supplied. Please choose one of the upload options and try again.

--- a/services/saml/signing/SamlCertificateService.cfc
+++ b/services/saml/signing/SamlCertificateService.cfc
@@ -51,6 +51,24 @@ component {
 		return result;
 	}
 
+	public string function getCertificateFingerprint( required string x509Cert, string algorithm="SHA-256" ) {
+		var certObj   = x509CertReader.read( arguments.x509Cert );
+		var derBytes  = certObj.getEncoded();
+		var digest    = CreateObject( "java", "java.security.MessageDigest" ).getInstance( arguments.algorithm );
+		var hashBytes = digest.digest( derBytes );
+		var sb        = CreateObject( "java", "java.lang.StringBuilder" );
+
+		for ( var i = 1; i <= ArrayLen( hashBytes ); i++ ) {
+			if ( i > 1 ) {
+				sb.append( ":" );
+			}
+			var hex = FormatBaseN( BitAnd( hashBytes[ i ], 255 ), 16 );
+			sb.append( UCase( hex.len() == 1 ? "0#hex#" : hex ) );
+		}
+
+		return sb.toString();
+	}
+
 	private string function _getCnForCertificates() {
 		var shortName = samlProviderMetadataGenerator.getMetaDataSettings().organisation_short_name;
 

--- a/services/saml/signing/SamlCertificateService.cfc
+++ b/services/saml/signing/SamlCertificateService.cfc
@@ -51,8 +51,8 @@ component {
 		return result;
 	}
 
-	public string function getCertificateFingerprint( required string x509Cert, string algorithm="SHA-256" ) {
-		var certObj   = x509CertReader.read( arguments.x509Cert );
+	public string function getCertificateFingerprint( required any x509Cert, string algorithm="SHA-256" ) {
+		var certObj   = IsSimpleValue( arguments.x509Cert ) ? x509CertReader.read( arguments.x509Cert ) : arguments.x509Cert;
 		var derBytes  = certObj.getEncoded();
 		var digest    = CreateObject( "java", "java.security.MessageDigest" ).getInstance( arguments.algorithm );
 		var hashBytes = digest.digest( derBytes );

--- a/tests/unit/SamlCertificateServiceTest.cfc
+++ b/tests/unit/SamlCertificateServiceTest.cfc
@@ -31,6 +31,14 @@ component extends="testbox.system.BaseSpec" {
 				expect( fingerprint ).toBe( "98:EF:0E:8E:21:9E:D4:2E:99:C5:C9:78:88:98:59:0C:58:F6:43:96" );
 			} );
 
+			it( "should return the correct SHA-256 fingerprint when passed a certificate object instead of a string", function() {
+				var svc         = _getService();
+				var certObj     = CreateObject( "app.extensions.preside-ext-saml2-sso.services.saml.signing.X509CertReader" ).read( _getTestCert() );
+				var fingerprint = svc.getCertificateFingerprint( certObj );
+
+				expect( fingerprint ).toBe( "4A:C0:DE:C4:5D:0A:77:F0:76:49:34:49:E1:71:17:90:CC:E2:03:A4:51:A2:A1:24:0A:3D:18:29:6A:C1:AA:9F" );
+			} );
+
 			it( "should format each byte as uppercase two-digit hex separated by colons", function() {
 				var svc         = _getService();
 				var fingerprint = svc.getCertificateFingerprint( _getTestCert() );

--- a/tests/unit/SamlCertificateServiceTest.cfc
+++ b/tests/unit/SamlCertificateServiceTest.cfc
@@ -1,0 +1,67 @@
+component extends="testbox.system.BaseSpec" {
+
+	function run() {
+		describe( "getCertificateFingerprint()", function() {
+			it( "should return the correct SHA-256 fingerprint for a known certificate using the default algorithm", function() {
+				var svc         = _getService();
+				var fingerprint = svc.getCertificateFingerprint( _getTestCert() );
+
+				expect( fingerprint ).toBe( "4A:C0:DE:C4:5D:0A:77:F0:76:49:34:49:E1:71:17:90:CC:E2:03:A4:51:A2:A1:24:0A:3D:18:29:6A:C1:AA:9F" );
+			} );
+
+			it( "should return the correct SHA-256 fingerprint when the certificate is wrapped in PEM headers", function() {
+				var svc         = _getService();
+				var certWithHeaders = "-----BEGIN CERTIFICATE-----" & Chr(10) & _getTestCert() & Chr(10) & "-----END CERTIFICATE-----";
+				var fingerprint = svc.getCertificateFingerprint( certWithHeaders );
+
+				expect( fingerprint ).toBe( "4A:C0:DE:C4:5D:0A:77:F0:76:49:34:49:E1:71:17:90:CC:E2:03:A4:51:A2:A1:24:0A:3D:18:29:6A:C1:AA:9F" );
+			} );
+
+			it( "should return the correct SHA-256 fingerprint when the SHA-256 algorithm is specified explicitly", function() {
+				var svc         = _getService();
+				var fingerprint = svc.getCertificateFingerprint( x509Cert=_getTestCert(), algorithm="SHA-256" );
+
+				expect( fingerprint ).toBe( "4A:C0:DE:C4:5D:0A:77:F0:76:49:34:49:E1:71:17:90:CC:E2:03:A4:51:A2:A1:24:0A:3D:18:29:6A:C1:AA:9F" );
+			} );
+
+			it( "should return the correct SHA-1 fingerprint when the SHA-1 algorithm is specified", function() {
+				var svc         = _getService();
+				var fingerprint = svc.getCertificateFingerprint( x509Cert=_getTestCert(), algorithm="SHA-1" );
+
+				expect( fingerprint ).toBe( "98:EF:0E:8E:21:9E:D4:2E:99:C5:C9:78:88:98:59:0C:58:F6:43:96" );
+			} );
+
+			it( "should format each byte as uppercase two-digit hex separated by colons", function() {
+				var svc         = _getService();
+				var fingerprint = svc.getCertificateFingerprint( _getTestCert() );
+
+				expect( fingerprint ).toMatch( "^([0-9A-F]{2}:)+[0-9A-F]{2}$" );
+			} );
+		} );
+	}
+
+	private any function _getService() {
+		return CreateObject( "app.extensions.preside-ext-saml2-sso.services.saml.signing.SamlCertificateService" ).init();
+	}
+
+	private string function _getTestCert() {
+		return "MIIDHDCCAgSgAwIBAgIJAPkZY/RifCMCMA0GCSqGSIb3DQEBCwUAMA8xDTALBgNV
+BAMTBHRlc3QwHhcNMTQxMTEyMTEwMTM1WhcNMjQxMTA5MTEwMTM1WjAPMQ0wCwYD
+VQQDEwR0ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwbnYcv3B
+IHH5O1Nu9aOw7IgjsYrzTFGmx/R/Lgbyh03t34FkAQ9SZ4ToKHRI7wJuHN2SveV2
+LBjZ8PgoM7Nzkryl2fpF6sytuqMhKFzdSEbHEXMn1GqKCQoQGno5jzZAtcyqxXrF
+iK5WrwSuPbopgGzu9UyPfaxaqmYVN0BW50z3NlKEZoQsc8w5WR9r1GDLNTSG0Jqx
+sCpzRktkdKAsjskRiqp0X/gFquBEwajyWqF08PGsfwW0iqISc+bCmD1IWGZCQLcy
+7eanVD3w13oFNPmqmxZSIiNNSXP5Gb7jcBZ+xWORwnIGOTBeThIPEWOlO4Kr7dDC
+2fm1YW1OiJwRPQIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1P
+cGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQUwN4Ob3oWtiCr
+FwqrickuFNGD/e8wHwYDVR0jBBgwFoAUwN4Ob3oWtiCrFwqrickuFNGD/e8wDQYJ
+KoZIhvcNAQELBQADggEBAEOVm9crJjxi8CPsqJZEfV4ZnO4IlDyEFt3zNpKyamsC
+01KFXkldoUhg1YNjLkpueysSyCpYrVe3BgkWdEccPO1GrGWYCYOgT3lf9LQ9hH5z
+KTrkC+vftsNFv8YwWQgrncNscMPldbC6ig0khE2IC3mGJMKR8MgHLJWlNV3txgR5
+Ri4pgGB+Ax6on6oQHks4I4EvDti7vtarY62Vuu8K6lJHltPkM6BjmQo2n0qJE9Hd
+4Cp1NN51cLFIhjRA/gurU7ZUJMg84oaEpG+CVQn0ckKLb9JiKajXSh8HvjX5+COk
+GvUxcf3q5ZXwJL6K+o0lrNadM/TN+8gZW441MEjl8Fc=";
+	}
+
+}

--- a/tests/unit/SamlCertificateServiceTest.cfc
+++ b/tests/unit/SamlCertificateServiceTest.cfc
@@ -10,9 +10,9 @@ component extends="testbox.system.BaseSpec" {
 			} );
 
 			it( "should return the correct SHA-256 fingerprint when the certificate is wrapped in PEM headers", function() {
-				var svc         = _getService();
+				var svc             = _getService();
 				var certWithHeaders = "-----BEGIN CERTIFICATE-----" & Chr(10) & _getTestCert() & Chr(10) & "-----END CERTIFICATE-----";
-				var fingerprint = svc.getCertificateFingerprint( certWithHeaders );
+				var fingerprint     = svc.getCertificateFingerprint( certWithHeaders );
 
 				expect( fingerprint ).toBe( "4A:C0:DE:C4:5D:0A:77:F0:76:49:34:49:E1:71:17:90:CC:E2:03:A4:51:A2:A1:24:0A:3D:18:29:6A:C1:AA:9F" );
 			} );

--- a/views/renderers/content/x509summary/default.cfm
+++ b/views/renderers/content/x509summary/default.cfm
@@ -1,5 +1,7 @@
 <cfscript>
-	certElId = "certificate-" & CreateUUId();
+	certElId   = "certificate-" & CreateUUId();
+	sha256ElId = "sha256-" & CreateUUId();
+	sha1ElId   = "sha1-" & CreateUUId();
 </cfscript>
 <cfoutput>
 	<div class="table-responsive-lg">
@@ -25,7 +27,19 @@
 					<td><a data-toggle="collapse" data-target="###certElId#" aria-expanded="false" aria-controls="#certElId#"><i class="fa fa-fw fa-eye"></i></a></td>
 				</tr>
 				<tr id="#certElId#" class="collapse">
-					<td style="vertical-align:top" colspan="2"><pre><code>#args.data#</code></pre </td>
+					<td style="vertical-align:top" colspan="2"><pre><code>#args.data#</code></pre></td>
+				</tr>
+				<tr>
+					<th style="vertical-align:top">#translateResource( "saml2:x509.info.table.fingerprint.sha1.th")#</th>
+					<td style="vertical-align:top">
+						<code id="#sha1ElId#" style="word-break:break-all;">#args.certInfo.fingerprintSha1#</code>
+					</td>
+				</tr>
+				<tr>
+					<th style="vertical-align:top">#translateResource( "saml2:x509.info.table.fingerprint.sha256.th")#</th>
+					<td style="vertical-align:top">
+						<code id="#sha256ElId#" style="word-break:break-all;">#args.certInfo.fingerprintSha256#</code>
+					</td>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
Display SHA-1 and SHA-256 fingerprints of the certificate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive UI metadata and a small helper in `SamlCertificateService` to compute certificate digests, covered by new unit tests and not altering auth/signing behavior.
> 
> **Overview**
> Adds SHA-1 and SHA-256 fingerprint support for X.509 certificates shown in the SAML admin UI.
> 
> `X509Summary` now computes fingerprints via a new `SamlCertificateService.getCertificateFingerprint()` helper (MessageDigest over DER bytes) and the `x509summary` view renders both values with new i18n labels; includes a dedicated unit test suite validating formatting, algorithms, and PEM-wrapped input.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec1c3bde3e357c48923cae67a0ec538c0c2c0436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->